### PR TITLE
Fixed typo in authors output file

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Available commands:
 
 **Example**
 ```bash
-$ bin/svn2git fetch-svn-authors svn://example.com/svnrepo --output authors-tranform.txt
+$ bin/svn2git fetch-svn-authors svn://example.com/svnrepo --output authors-transform.txt
 ```
 
 Edit the output file if you want to make adjustments to the layout. Default layout is:


### PR DESCRIPTION
If you follow the README example commands you will get the message:

```
$ bin/svn2git migrate svn://example.com/repo -A authors-transform.txt --remote=GIT-REPO.git
BASEDIR: /Users/agrunwald/Development/Source/svn2git.php.git
SOURCE: ...
NAME: deploy-prepare_release
TMP: /Users/agrunwald/Development/Source/svn2git.php.git/tmp/...
AUTHORS-FILE: authors-transform.txt
REMOTE: ...
==========================================================
Cloning subversion repository...
git svn clone ... --prefix=svn/ --stdlayout --quiet -A authors-transform.txt /Users/agrunwald/Development/Source/svn2git.php.git/tmp/....
Can't open authors-transform.txt No such file or directory

  [RuntimeException]
  Unable to execute 'git svn clone ... --prefix=svn/ --stdlayout --quiet -A authors-transform.txt /Users/agrunwald/Development/S
  ource/svn2git.php.git/tmp/...'

migrate [-A|--authors-file="..."] [--remote="..."] [--preserve-empty-dirs] [--placeholder-filename="..."] source
```

This PR fixes the correct name of the authors output file name.
